### PR TITLE
drop locale IT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ jdk:
 before_install:
   - JAVA_HOME=$(jdk_switcher home openjdk8) ./gradlew
 
+script: ./gradlew check --info
+
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/


### PR DESCRIPTION
because it fails if another LanguageConfig with a preceding name is on the classpath -- only the first locale is returned!