### PR TITLE
drop name IT

### DIFF
--- a/src/main/groovy/de/dfki/mary/tasks/GenerateSource.groovy
+++ b/src/main/groovy/de/dfki/mary/tasks/GenerateSource.groovy
@@ -106,7 +106,7 @@ class GenerateSource extends DefaultTask {
                                    |        [
                                    |""".stripMargin() +
                                         project.marytts.component.config.findAll {
-                                            it.key != 'locale'
+                                            !(it.key in ['locale', 'name'])
                                         }.collect { name, value ->
                                             if (value instanceof List) {
                                                 return "            ['${name}.list', ${value.collect { '\'' + it + '\'' }}]"


### PR DESCRIPTION
similar to #7, a name component config key may conflict with, for one thing, the `marybase` MaryConfig